### PR TITLE
Supports downloading ZIP files for >1 target files

### DIFF
--- a/examples/jobs/start_job.py
+++ b/examples/jobs/start_job.py
@@ -7,6 +7,16 @@ zamzar \
     .convert("path/to/your/file.docx", "pdf") \
     .store("path/to/your/file.pdf")
 
+# Convert a local file that produces multiple output files (e.g. a multi-page PDF to PNGs)
+zamzar \
+    .convert("path/to/your/multipage.pdf", "png") \
+    .store("path/to/output_directory")
+
+# Convert a local file that produces multiple output files and download them as a ZIP file
+zamzar \
+    .convert("path/to/your/multipage.pdf", "png") \
+    .store("path/to/output.zip", extract_multiple_file_output=False)
+
 # Convert a remote file, wait for it to complete (or throw an exception if it fails), and download the result
 zamzar \
     .convert("https://www.zamzar.com/images/zamzar-logo.png", "jpg") \

--- a/test/facade/test_job_manager.py
+++ b/test/facade/test_job_manager.py
@@ -38,7 +38,8 @@ class TestJobManager:
         """Test that a multi-file job can be stored."""
         output = tmp_path / "output"
 
-        zamzar.jobs.find(succeeding_multi_output_job_id).await_completion().store(output)
+        job = zamzar.jobs.find(succeeding_multi_output_job_id)
+        job.await_completion().store(output)
         assert_non_empty_file(output)
 
         pngs = list(tmp_path.glob('*.png'))
@@ -51,11 +52,24 @@ class TestJobManager:
         pngs = list(tmp_path.glob('*.png'))
         assert len(pngs) == 0, "Sanity check: expected output files not to exist yet"
 
-        zamzar.jobs.find(succeeding_multi_output_job_id).await_completion().store(tmp_path)
+        job = zamzar.jobs.find(succeeding_multi_output_job_id)
+        job.await_completion().store(tmp_path)
         pngs = list(tmp_path.glob('*.png'))
         assert len(pngs) == 3
         for png in pngs:
             assert_non_empty_file(png)
+
+    def test_store_multi_file_job_no_extract(self, zamzar, succeeding_multi_output_job_id, tmp_path):
+        """Test that a multi-file job can be stored without extracting the ZIP file."""
+        output = tmp_path / "output.zip"
+
+        job = zamzar.jobs.find(succeeding_multi_output_job_id)
+        job.await_completion().store(output, extract_multiple_file_output=False)
+        assert_non_empty_file(output)
+
+        # The PNG files should NOT exist since we did not extract the ZIP
+        pngs = list(tmp_path.glob('*.png'))
+        assert len(pngs) == 0
 
     def test_store_throws_when_no_target_files(self, zamzar, failing_job_id, tmp_path):
         """Test that an exception is thrown when trying to store a job with no target files."""

--- a/zamzar/facade/job_manager.py
+++ b/zamzar/facade/job_manager.py
@@ -72,15 +72,17 @@ class JobManager(Awaitable):
         """Returns the ID of the source file being converted."""
         return self.model.source_file.id if self.model.source_file else None
 
-    def store(self, target: Union[str, Path]) -> JobManager:
+    def store(self, target: Union[str, Path], extract_multiple_file_output: bool = True) -> JobManager:
         """
         Downloads all the target files produced by the conversion to the specified destination, blocking until the
         download is complete.
+
+        If extract_multiple_file_output is False and there are multiple target files, the ZIP file will not be extracted.
         """
         source = self.__primary_target_file()
         target = Path(target)
         destination = self._zamzar.files._download_model(source, target)
-        if len(self.target_file_ids) > 1:
+        if len(self.target_file_ids) > 1 and extract_multiple_file_output:
             JobManager.__extract(destination)
         return self
 


### PR DESCRIPTION
Clients can now download the ZIP file for conversions that result in >1 target file:

```python
zamzar \
    .convert("path/to/your/multipage.pdf", "png") \
    .store("path/to/output.zip", extract_multiple_file_output=False)
```